### PR TITLE
Add refactoring testcode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/acmk189/todo_app_REST_API
 
 go 1.22.5
+
+require golang.org/x/sync v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=

--- a/main.go
+++ b/main.go
@@ -4,21 +4,32 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
+	"os"
 
 	"golang.org/x/sync/errgroup"
 )
 
 func main() {
-	if err := run(context.Background()); err != nil {
+	if len(os.Args) != 2 {
+		log.Printf("need port number\n")
+		os.Exit(1)
+	}
+	p := os.Args[1]
+	l, err := net.Listen("tcp", ":"+p)
+	if err != nil {
+		log.Fatalf("failed to listen port: %s: %v", p, err)
+	}
+	if err := run(context.Background(), l); err != nil {
 		log.Printf("failed to teminate server: %v", err)
+		os.Exit(1)
 	}
 }
 
-func run(cxt context.Context) error {
+func run(cxt context.Context, l net.Listener) error {
 
 	s := &http.Server{
-		Addr: ":8080",
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
 		}),
@@ -28,7 +39,7 @@ func run(cxt context.Context) error {
 	// 別ゴルーチンでHTTPサーバを起動
 	eg.Go(func() error {
 		// http.ErrServerClosed は http.Server.Shutdown() の正常終了なのでエラーではない
-		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := s.Serve(l); err != nil && err != http.ErrServerClosed {
 			log.Printf("failed to close: %+v", err)
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -1,22 +1,44 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"net/http"
-	"os"
+
+	"golang.org/x/sync/errgroup"
 )
 
 func main() {
-	err := http.ListenAndServe(
-		"localhost:8080",
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
-		}),
-	)
-	if err != nil {
-		fmt.Printf("faild to terminate server: %v", err)
-		os.Exit(1)
+	if err := run(context.Background()); err != nil {
+		log.Printf("failed to teminate server: %v", err)
 	}
 }
 
-// branch-test
+func run(cxt context.Context) error {
+
+	s := &http.Server{
+		Addr: ":8080",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
+		}),
+	}
+
+	eg, ctx := errgroup.WithContext(cxt)
+	// 別ゴルーチンでHTTPサーバを起動
+	eg.Go(func() error {
+		// http.ErrServerClosed は http.Server.Shutdown() の正常終了なのでエラーではない
+		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("failed to close: %+v", err)
+			return err
+		}
+		return nil
+	})
+
+	// チャネルからの終了通知を受け取る
+	<-ctx.Done()
+	if err := s.Shutdown(context.Background()); err != nil {
+		log.Printf("failed to shutdown: %+v", err)
+	}
+	return eg.Wait()
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func TestRun(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return run(ctx)
+	})
+	in := "message"
+	rsp, err := http.Get("http://localhost:8080/" + in)
+	if err != nil {
+		t.Errorf("failed to get: %+v", err)
+	}
+	defer rsp.Body.Close()
+	got, err := io.ReadAll(rsp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+
+	// httpサーバーの戻り値を検証
+	want := fmt.Sprintf("Hello, %s!", in)
+	if string(got) != want {
+		t.Errorf("want %q, but got %q", want, got)
+	}
+
+	// run関数に終了通知を送る
+	cancel()
+	// run関数の戻り値(errgroup.Group.Wait())を検証する
+	if err := eg.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## 内容
- httpサーバーへの接続処理を`run`関数に移す
- `http.Server`型によるサーバー起動と`context.Context`型による外部からの終了通知を待機する関数とする
  - [errgroupパッケージ](https://pkg.go.dev/golang.org/x/sync/errgroup)
  - `*errgroup.Group.Go`メソッドで、関数(ここではHTTPサーバー起動)を新しいゴルーチンで呼び出す
  - `<-ctx.Done()`で終了通知を待つ
  - `eg.Wait()`で別のゴルーチン完了を待機